### PR TITLE
Add missing `await` to setViewport() calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ async function main() {
   const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });
   let page = await browser.newPage();
 
-  page.setViewport({ width: 640, height: 680 });
+  await page.setViewport({ width: 640, height: 680 });
   await page.goto(`file://${__dirname}/index.html`);
   await new Promise(res => setTimeout(() => res(), 300));
   await page.screenshot({ path: 'screenshot/index.png' });

--- a/capture.js
+++ b/capture.js
@@ -5,7 +5,7 @@ async function main() {
   const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });
   let page = await browser.newPage();
 
-  page.setViewport({ width: 640, height: 680 });
+  await page.setViewport({ width: 640, height: 680 });
   await page.goto(`file://${__dirname}/index.html`);
   await new Promise(res => setTimeout(() => res(), 300));
   await page.screenshot({ path: 'screenshot/index.png' });


### PR DESCRIPTION
puppeteer's `Page.prototype.setViewport` method is an async method.

https://github.com/GoogleChrome/puppeteer/blob/v0.13.0/lib/Page.js#L588

I added `await` to the method calls to ensure to start browsing after viewport is set.